### PR TITLE
remove htmlspecialchars_decode from JSON output

### DIFF
--- a/src/Datalayer.php
+++ b/src/Datalayer.php
@@ -374,16 +374,13 @@ class Datalayer {
 		if ( empty( $account_id ) ) {
 			return;
 		}
-
-		// Get the data.
-		$data = wp_json_encode( $this->get_data() );
 		
 		?>
 		<script>
 		// Map the datalayer values before initiation.
 		window.dataLayer      = window.dataLayer || [];
 		window.tenupDataLayer = window.tenupDataLayer || [];
-		window.tenupDataLayer = <?php echo htmlspecialchars_decode( $data ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Need the & in URL. ?>;
+		window.tenupDataLayer = <?php echo wp_json_encode( $this->get_data() ); ?>;
 		// Set the session storage for the URL parameters.
 		const params = ['utm_source', 'utm_medium', 'utm_campaign', 'gclid', 'fbclid', 'msclkid'];
 		params.forEach((param) => {

--- a/src/Datalayer.php
+++ b/src/Datalayer.php
@@ -34,8 +34,6 @@ class Datalayer {
 	public function __construct() {
 		$this->register_scripts();
 		$this->header_scripts();
-
-		add_filter( 'tenup_datalayer_data_values', [ $this, 'html_encode_fields' ] );
 	}
 
 	/**
@@ -74,17 +72,6 @@ class Datalayer {
 
 		// Return the prepared data.
 		return $this->data;
-	}
-
-	public function html_encode_fields( $data ) {
-
-		foreach ( $data as $key => $value ) {
-			if ( is_string( $value ) ) {
-				$data[ $key ] = html_entity_decode( $value );
-			}
-		}
-
-		return $data;
 	}
 
 	/**

--- a/src/Datalayer.php
+++ b/src/Datalayer.php
@@ -34,6 +34,8 @@ class Datalayer {
 	public function __construct() {
 		$this->register_scripts();
 		$this->header_scripts();
+
+		add_filter( 'tenup_datalayer_data_values', [ $this, 'html_encode_fields' ] );
 	}
 
 	/**
@@ -72,6 +74,17 @@ class Datalayer {
 
 		// Return the prepared data.
 		return $this->data;
+	}
+
+	public function html_encode_fields( $data ) {
+
+		foreach ( $data as $key => $value ) {
+			if ( is_string( $value ) ) {
+				$data[ $key ] = html_entity_decode( $value );
+			}
+		}
+
+		return $data;
 	}
 
 	/**
@@ -268,7 +281,7 @@ class Datalayer {
 
 				if ( ! empty( $terms ) ) {
 					foreach ( $terms as $term ) {
-						$this->data[ $type ][] = apply_filters( 'tenup_datalayer_taxonomy_' . $type . '_name', $term->name, $term );
+						$this->data[ $type ][] = apply_filters( 'tenup_datalayer_taxonomy_' . $type . '_name', htmlspecialchars_decode( $term->name ), $term );
 					}
 				}
 			}


### PR DESCRIPTION
### Description of the Change
Removes `htmlspecialchars_decode()` from the JSON output of data values. Special character are encoded earlier in the process, but this function undoes the work. The original `Need the & in URL.` comment does not seem valid.

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - New feature
> Changed - Existing functionality
> Deprecated - Soon-to-be removed feature
> Removed - Feature
> Fixed - Bug fix
> Security - Vulnerability


### Credits
@gthayer


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
