### PR TITLE
Add action after GTM loader

### DIFF
--- a/src/Datalayer.php
+++ b/src/Datalayer.php
@@ -441,6 +441,8 @@ class Datalayer {
 			j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 			'https://www.googletagmanager.com/gtm.js?id='+i+dl<?php echo $params_string; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Need the & in URL. ?>;f.parentNode.insertBefore(j,f);
 		})(window,document,'script','dataLayer','<?php echo esc_js( $account_id ); ?>');
+
+		<?php do_action( 'tenup_datalayer_after_gtm_head_script' ); ?>
 		</script>
 		<!-- End Google Tag Manager -->
 


### PR DESCRIPTION
### Description of the Change
This PR adds an action after the GTM loader, to mirror the action directly before the loader.

This will not close any issues, but will allow wrapping the GTM loader in custom code as needed.

### Changelog Entry
> Added - Created a new action after GTM loader

### Credits
Props @banderon

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
